### PR TITLE
types/firebaseDocTypes.tsの細かい修正

### DIFF
--- a/src/types/fiebaseDocTypes.ts
+++ b/src/types/fiebaseDocTypes.ts
@@ -5,3 +5,15 @@ export interface taskItemType {
     orderNum: number;
     taskName: string;
 }
+
+export interface postItemType {
+    createDate: string;
+    task: string;
+    startTime: string;
+    endTime: string;
+    kensu: number;
+    User: string;
+    workingHour: number;
+    perHour: number;
+    DateTimeNum: number;
+}


### PR DESCRIPTION
# 概要
types/firebaseDocTypes.tsのsave忘れ、ファイル名typoをfix