### PR TITLE
startTime,endTimeを更新の際に秒を削除するよう変更

### DIFF
--- a/src/feature/components/home/TasksForm.tsx
+++ b/src/feature/components/home/TasksForm.tsx
@@ -40,6 +40,9 @@ const TasksForm = ({cardMoved, setCardMoved, postUserName, postDate}: ChildCompo
     const taskItems: taskItemType[] = data ? data.filter(item => item.chk) : []
 
     const editTask = ({id, field, value}: updateTaskAction) => {
+        if((field === "startTime" || field === "endTime") && typeof value === "string" && value.split(":").length === 3){
+            value = value.slice(0, -3)
+        }
         const action = {id, field, value}
         dispatch(updateTask(action))
     }


### PR DESCRIPTION
# 概要
通常Inputタグのtype="time"は00:00などの分単位までの表記になるが
ブラウザ側で00:00:00の表記に変更することが可能だったため
秒まで表記があった場合削除するように変更