### PR TITLE
CSVダウンロード時に全タスク名が取得できないエラー解消

### DIFF
--- a/src/app/general/sendlist/page.tsx
+++ b/src/app/general/sendlist/page.tsx
@@ -41,6 +41,7 @@ const SendList = () => {
                 setIsLoading={setIsLoading} 
                 setAllItems={setAllItems} 
                 taskItems={taskItems}
+                allTaskItems={allTaskItems}
                 allItems={allItems}
                 setCurrentPage={setCurrentPage}
                 userName={userName!}

--- a/src/app/manager/sendlist/page.tsx
+++ b/src/app/manager/sendlist/page.tsx
@@ -39,6 +39,7 @@ const SendList = () => {
                 setIsLoading={setIsLoading} 
                 setAllItems={setAllItems} 
                 taskItems={taskItems}
+                allTaskItems={allTaskItems}
                 allItems={allItems}
                 setCurrentPage={setCurrentPage}
                 userName="ALL"

--- a/src/feature/components/sendlist/SearchComp.tsx
+++ b/src/feature/components/sendlist/SearchComp.tsx
@@ -12,12 +12,13 @@ type ChildComponentProps = {
     setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
     setAllItems: React.Dispatch<React.SetStateAction<listItemType[]>>;
     taskItems: taskItemType[];
+    allTaskItems: taskItemType[];
     allItems: listItemType[];
     setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
     userName: string
 };
 
-const SearchComp = ({setIsLoading, setAllItems, taskItems, allItems, setCurrentPage, userName}: ChildComponentProps) => {
+const SearchComp = ({setIsLoading, setAllItems, taskItems, allTaskItems, allItems, setCurrentPage, userName}: ChildComponentProps) => {
     const [startDate, setStartDate] = useState<string>(new Date().toLocaleDateString('sv-SE'));
     const [endDate, setEndDate] = useState<string>(new Date().toLocaleDateString('sv-SE'));
     const [searchName, setSearchName] = useState<string>(userName);
@@ -81,14 +82,14 @@ const SearchComp = ({setIsLoading, setAllItems, taskItems, allItems, setCurrentP
             return "" + now.getFullYear() + padZero(now.getMonth() + 1) + padZero(now.getDate()) + padZero(now.getHours()) + padZero(now.getMinutes());
         };
 
-        if(!taskItems) {
+        if(!allTaskItems) {
             window.alert("業務項目名が正しく読み込めていません。")
             return
         }
         const csvName = "業務報告_" + getCurrentDatetime();
         const props = {
             data: allItems,
-            taskItems,
+            allTaskItems,
             filename: csvName,
         }
         downloadCSV(props)

--- a/src/lib/CSVdownloader.ts
+++ b/src/lib/CSVdownloader.ts
@@ -2,17 +2,17 @@ import { listItemType, taskItemType } from "@/types/firebaseDocTypes";
 
 type propsType = {
     data: listItemType[],
-    taskItems: taskItemType[],
+    allTaskItems: taskItemType[],
     filename: string,
 }
 
-export const downloadCSV = ({data, taskItems, filename}: propsType) => {
+export const downloadCSV = ({data, allTaskItems, filename}: propsType) => {
     if (!data || !data.length) return;
 
     const headers = ["日付", "業務項目", "開始時間", "終了時間", "業務時間", "件数", "時速", "従業員名"];
 
     const rows = data.map((item) => {
-        const taskItem = taskItems?.filter(taskItem => String(taskItem.id) === item.task)
+        const taskItem = allTaskItems?.filter(taskItem => String(taskItem.id) === item.task)
         const taskName = taskItem.length === 1 ? taskItem[0].taskName ? taskItem[0].taskName : "" : ""
         return ([
             item.date,


### PR DESCRIPTION
# 概要
CSVダウンロードの関数に渡していたプロップスが
全タスクではなく、表示をしているタスクのみを渡していたため
ダウンロード時に空白が大量に発生。

全タスクを渡すことで上記バグを解消